### PR TITLE
clearing the property editor when a component is deleted.

### DIFF
--- a/src/app/layout-editor/property-editor/property-editor.component.html
+++ b/src/app/layout-editor/property-editor/property-editor.component.html
@@ -1,4 +1,4 @@
-<mat-list>
+<mat-list *ngIf="componentModel">
   <h3>
     Properties
   </h3>

--- a/src/app/layout-editor/property-editor/property-editor.component.spec.ts
+++ b/src/app/layout-editor/property-editor/property-editor.component.spec.ts
@@ -232,4 +232,13 @@ describe('PropertyEditorComponent', () => {
       expect(result).toBeNull();
     });
   });
+
+  it('should clear model when component is deleted', () => {
+    component.propertyEditorComponent.componentModel = new MockEditorComponentModel();
+    component.propertyEditorComponent['handleToolbarMessage']({
+      command: Command.delete,
+      data: undefined
+    });
+    expect(component.propertyEditorComponent.componentModel).toBeUndefined();
+  });
 });

--- a/src/app/layout-editor/property-editor/property-editor.component.spec.ts
+++ b/src/app/layout-editor/property-editor/property-editor.component.spec.ts
@@ -36,6 +36,7 @@ class MockPropertyEditorComponent {
 describe('PropertyEditorComponent', () => {
   let component: MockPropertyEditorComponent;
   let fixture: ComponentFixture<MockPropertyEditorComponent>;
+  let subSpy;
 
   beforeEach(
     async(() => {
@@ -61,11 +62,16 @@ describe('PropertyEditorComponent', () => {
       fixture = TestBed.createComponent(MockPropertyEditorComponent);
       component = fixture.componentInstance;
       component.model = new EditorLayoutModel();
+      subSpy = spyOn(
+        component.propertyEditorComponent['subscriptions'],
+        'push'
+      );
       fixture.detectChanges();
     });
 
     it('should create', () => {
       expect(component).toBeTruthy();
+      expect(subSpy).toHaveBeenCalled();
     });
 
     it('should change name', () => {

--- a/src/app/layout-editor/property-editor/property-editor.component.ts
+++ b/src/app/layout-editor/property-editor/property-editor.component.ts
@@ -11,7 +11,10 @@ import {
 import { Subscription } from 'rxjs/Subscription';
 import { EditorGridModel, EditorLayoutModel, EditorTextModel } from '../models';
 import { MatButtonToggleChange } from '@angular/material';
-import { PropertyEditorMessage } from '../../core/messages';
+import {
+  PropertyEditorMessage,
+  ToolbarMessage
+} from '../../core/messages';
 import { Command } from '../../core/enums';
 import { MessageService } from '../../core/services';
 import { FormControl, Validators } from '@angular/forms';
@@ -72,7 +75,13 @@ export class PropertyEditorComponent implements OnInit, OnDestroy {
     private messageService: MessageService
   ) {}
 
-  ngOnInit() {}
+  ngOnInit() {
+    this.subscriptions.push(
+      this.messageService
+        .channel(ToolbarMessage)
+        .subscribe(msg => this.handleToolbarMessage(msg))
+    );
+  }
 
   ngOnDestroy() {
     this.subscriptions.forEach(sub => sub.unsubscribe());
@@ -137,5 +146,11 @@ export class PropertyEditorComponent implements OnInit, OnDestroy {
       command: Command.propertyChange,
       data: this.componentModel
     });
+  }
+
+  private handleToolbarMessage(msg: ToolbarMessage) {
+    if (msg.command === Command.delete) {
+      this.componentModel = undefined;
+    }
   }
 }


### PR DESCRIPTION
resolve #29 